### PR TITLE
Fix: wrong type comments

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -38,7 +38,7 @@ class Client
     
     /**
      * Construct.
-     * @param array/string $servers
+     * @param array | string $servers
      */
     public function __construct($servers)
     {


### PR DESCRIPTION
The original comment will report an error warning like:
```
Argument '1' passed to __construct() is expected to be of type array, string givenPHP(PHP0406)
```